### PR TITLE
ability to set replicas

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module "kubernetes-controller" {
 | <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Specifies the node selector which must match a node's labels for the Ocean Controller resources to be scheduled on that node | `map(string)` | `null` | no |
 | <a name="input_proxy_url"></a> [proxy\_url](#input\_proxy\_url) | Specifies the proxy server URL to communicate through | `string` | `null` | no |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Specifies the name of the Helm release | `string` | `"ocean-controller"` | no |
+| <a name="input_replicas"></a> [replicas](#input\_replicas) | Controls number of replicas | `number` | `null` | no |
 | <a name="input_resources_limits"></a> [resources\_limits](#input\_resources\_limits) | Specifies the definition of the maximum amount of compute resources allowed | `map(any)` | `null` | no |
 | <a name="input_resources_requests"></a> [resources\_requests](#input\_resources\_requests) | Specifies the definition of the minimum amount of compute resources required | `map(any)` | `null` | no |
 | <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Overrides the default secret name | `string` | `null` | no |
@@ -58,7 +59,7 @@ module "kubernetes-controller" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.12.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.12.1 |
 ## Requirements
 
 | Name | Version |

--- a/main.tf
+++ b/main.tf
@@ -176,4 +176,12 @@ resource "helm_release" "ocean-kubernetes-controller" {
       value = var.deploy_metrics_server
     }
   }
+
+  dynamic "set" {
+    for_each = var.replicas != null ? [1] : []
+    content {
+      name  = "replicas"
+      value = var.replicas
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,3 +214,9 @@ variable "deploy_metrics_server" {
   description = "Controls whether the metrics server should be deployed"
   default     = false
 }
+
+variable "replicas" {
+  type        = number
+  description = "Controls number of replicas"
+  default     = null
+}


### PR DESCRIPTION
Hi.
On non-critical environments, such as DEV clusters, it doesn't make sense to run high-available setup and that way save couple cents. I've added `replicas` parameter to allow that - it was already possible in Helm, so hope it's fine.