### PR TITLE
helm: upgrade to version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ module "kubernetes-controller" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.12.1, < 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.0 |
 <!-- END_TF_DOCS -->
 
 ## Documentation

--- a/example/backwards-compatible-installation/main.tf
+++ b/example/backwards-compatible-installation/main.tf
@@ -1,5 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}
+
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"
   }
 }

--- a/example/values-file-installation/main.tf
+++ b/example/values-file-installation/main.tf
@@ -1,5 +1,14 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}
+
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path = "~/.kube/config"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -25,171 +25,97 @@ resource "helm_release" "ocean-kubernetes-controller" {
   ]
 
   # ...Or set values directly from variables
-  dynamic "set_sensitive" {
-    for_each = var.spotinst_token != null ? [1] : []
-    content {
-      name  = "spotinst.token"
-      value = var.spotinst_token
-    }
-  }
+  set_sensitive = var.spotinst_token != null ? [{
+    name  = "spotinst.token"
+    value = var.spotinst_token
+  }] : []
 
-  dynamic "set" {
-    for_each = var.spotinst_account != null ? [1] : []
-    content {
+  set = concat(
+    var.spotinst_account != null ? [{
       name  = "spotinst.account"
       value = var.spotinst_account
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.cluster_identifier != null ? [1] : []
-    content {
+    }] : [],
+    var.cluster_identifier != null ? [{
       name  = "spotinst.clusterIdentifier"
       value = var.cluster_identifier
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.controller_image != null ? [1] : []
-    content {
+    }] : [],
+    var.controller_image != null ? [{
       name  = "image.repository"
       value = var.controller_image
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.controller_version != null ? [1] : []
-    content {
+    }] : [],
+    var.controller_version != null ? [{
       name  = "image.tag"
       value = var.controller_version
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.image_pull_policy != null ? [1] : []
-    content {
+    }] : [],
+    var.image_pull_policy != null ? [{
       name  = "image.pullPolicy"
       value = var.image_pull_policy
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.base_url != null ? [1] : []
-    content {
+    }] : [],
+    var.base_url != null ? [{
       name  = "spotinst.baseUrl"
       value = var.base_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.proxy_url != null ? [1] : []
-    content {
+    }] : [],
+    var.proxy_url != null ? [{
       name  = "spotinst.proxyUrl"
       value = var.proxy_url
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.enable_csr_approval != null ? [1] : []
-    content {
+    }] : [],
+    var.enable_csr_approval != null ? [{
       name  = "spotinst.enableCsrApproval"
       value = var.enable_csr_approval
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.disable_auto_update != null ? [1] : []
-    content {
+    }] : [],
+    var.disable_auto_update != null ? [{
       name  = "spotinst.disableAutoUpdate"
       value = var.disable_auto_update
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.disable_rightsizing != null ? [1] : []
-    content {
+    }] : [],
+    var.disable_rightsizing != null ? [{
       name  = "spotinst.disableAutomaticRightSizing"
       value = var.disable_rightsizing
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.readonly_mode != null ? [1] : []
-    content {
+    }] : [],
+    var.readonly_mode != null ? [{
       name  = "spotinst.readonly"
       value = var.readonly_mode
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.image_pull_secrets
-    content {
-      name  = "imagePullSecrets[${index(var.image_pull_secrets, set.value)}].name"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.resources_limits != null ? var.resources_limits : {}
-    content {
-      name  = "resources.limits.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.resources_requests != null ? var.resources_requests : {}
-    content {
-      name  = "resources.requests.${set.key}"
-      value = set.value
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.secret_name != null ? [1] : []
-    content {
+    }] : [],
+    [
+      for idx, secret in var.image_pull_secrets : {
+        name  = "imagePullSecrets[${idx}].name"
+        value = secret
+      }
+    ],
+    [
+      for key, value in var.resources_limits != null ? var.resources_limits : {} : {
+        name  = "resources.limits.${key}"
+        value = value
+      }
+    ],
+    [
+      for key, value in var.resources_requests != null ? var.resources_requests : {} : {
+        name  = "resources.requests.${key}"
+        value = value
+      }
+    ],
+    var.secret_name != null ? [{
       name  = "secret.name"
       value = var.secret_name
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.service_account_name != null ? [1] : []
-    content {
+    }] : [],
+    var.service_account_name != null ? [{
       name  = "serviceAccount.name"
       value = var.service_account_name
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.config_map_name != null ? [1] : []
-    content {
+    }] : [],
+    var.config_map_name != null ? [{
       name  = "configMap.name"
       value = var.config_map_name
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.ca_bundle_secret_name != null ? [1] : []
-    content {
+    }] : [],
+    var.ca_bundle_secret_name != null ? [{
       name  = "caBundleSecret.name"
       value = var.ca_bundle_secret_name
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.deploy_metrics_server != null ? [1] : []
-    content {
+    }] : [],
+    var.deploy_metrics_server != null ? [{
       name  = "metrics-server.deployChart"
       value = var.deploy_metrics_server
-    }
-  }
-
-  dynamic "set" {
-    for_each = var.replicas != null ? [1] : []
-    content {
+    }] : [],
+    var.replicas != null ? [{
       name  = "replicas"
       value = var.replicas
-    }
-  }
+    }] : [],
+  )
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.12.1, < 3.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION
Feature: Upgrade Help Provider v2 -> v3

This PR upgrades the Help Provider from version 2 to version 3.
v3 is the current and actively maintained version, and linters already rely on it.
This ensures compatibility with existing tooling and aligns the project with the latest supported version.